### PR TITLE
Removed unnecessary line creating an extra object

### DIFF
--- a/kiteconnect/src/com/zerodhatech/ticker/KiteTicker.java
+++ b/kiteconnect/src/com/zerodhatech/ticker/KiteTicker.java
@@ -389,7 +389,6 @@ public class KiteTicker {
     public void subscribe(ArrayList<Long> tokens) {
         if(ws != null) {
             if (ws.isOpen()) {
-                createTickerJsonObject(tokens, mSubscribe);
                 ws.sendText(createTickerJsonObject(tokens, mSubscribe).toString());
                 subscribedTokens.addAll(tokens);
                 for(int i = 0; i < tokens.size(); i++){


### PR DESCRIPTION
There are 2 calls to made to createTickerJsonObject, the first one doesn't store the result and seems unnecessary. This falls in critical flow where the execution speed matters a lot.