### PR TITLE
Propagating exception message

### DIFF
--- a/kiteconnect/src/com/zerodhatech/kiteconnect/kitehttp/exceptions/KiteException.java
+++ b/kiteconnect/src/com/zerodhatech/kiteconnect/kitehttp/exceptions/KiteException.java
@@ -14,11 +14,13 @@ public class KiteException extends Throwable {
     // constructor that sets the message
     public KiteException(String message){
         this.message = message;
+        super(message);
     }
 
     // constructor that sets the message and code
     public KiteException(String message, int code){
         this.message = message;
         this.code = code;
+        super(message, code);
     }
 }


### PR DESCRIPTION
Propagating exception message to Exception class. This will helps getting the exception message even when Exception class is caught, and no additional handling is needed in case of KiteException.
Fixes https://github.com/zerodha/javakiteconnect/issues/31